### PR TITLE
peer locator: save reported peers to file

### DIFF
--- a/oonib/testhelpers/peer_locator_helpers.py
+++ b/oonib/testhelpers/peer_locator_helpers.py
@@ -3,8 +3,7 @@ from twisted.internet.protocol import Protocol, Factory, ServerFactory
 from oonib.config import config
 from oonib import log
 
-from random import randint
-peers_probes = []
+import random
 
 class PeerLocatorProtocol(Protocol):
     """
@@ -12,17 +11,28 @@ class PeerLocatorProtocol(Protocol):
     and send another pair in response
     """
     def dataReceived(self, data):
-        self_peer = self.transport.getPeer(),data
-        log.msg(str(self_peer))
+        self_peer = random_peer = '%s:%s' % (self.transport.getPeer().host, data)
+        log.msg("registering: %s" % self_peer)
         try:
-            self.peer_probes.append(self_peer)
-        except AttributeError:
-            self.peer_probes = [self_peer]
-            
-        random_peer = self_peer
-        while(len(self.peer_probes) > 1 and random_peer == self_peer):
-            random_peer = peer_probes[randint(0, peer_probes)]
+            with open(config.helpers['peer-locator'].peer_list, 'a+') as peer_list_file:
+                peer_list = [peer.strip() for peer in peer_list_file.readlines()]
+                if self_peer in peer_list:
+                    log.msg('we already know the peer')
+                else:
+                    log.msg('new peer %s' % self_peer)
+                    peer_list_file.write(self_peer + '\n')
+                    peer_list.append(self_peer)
+                peer_pool_size = len(peer_list)
 
+                log.msg(str(peer_list))
+                log.msg("choosing a random peer from pool of %d peers" % peer_pool_size)
+                while(peer_pool_size > 1 and random_peer == self_peer):
+                    random_peer = random.choice(peer_list)
+
+        except IOError as e:
+            log.msg("IOError %s" % e)
+
+        log.msg("seeding peer %s to peer %s" % (random_peer, self_peer))
         if (random_peer == self_peer):
             random_peer = ''
 


### PR DESCRIPTION
Save reported peers to a configurable plain text file (as ``HOST:PORT``).

Not original, based on an uncommitted fix by @vmon or @kheops2713, plus some
fixes and simplifications.