### PR TITLE
Peer locator local addr

### DIFF
--- a/oonib/testhelpers/peer_locator_helpers.py
+++ b/oonib/testhelpers/peer_locator_helpers.py
@@ -6,9 +6,9 @@ from oonib import log
 import random
 import re
 
-_max_data_len = len('[0123:4567:89ab:cdef:0123:4567:89ab:cdef]:65535')
-# Accept ``PORT`` or ``ADDR:PORT`` with IPv4 ``ADDR`` or IPv6 ``[ADDR]``.
-_data_re = re.compile('^(?:([.0-9]+|\[[:0-9a-fA-F]+\]):)?([0-9]+)$')
+# Accept ``PORT[ FLAG]...``.
+_max_data_len = 100
+_data_re = re.compile(r'^([0-9]+)( [_a-z]+)*$')
 
 class PeerLocatorProtocol(Protocol):
     """
@@ -16,15 +16,19 @@ class PeerLocatorProtocol(Protocol):
     and send another pair in response
     """
     def dataReceived(self, data):
-        match = _data_re.match(data[:_max_data_len])  # protect against garbage
-        if not match:
+        # Protect against garbage.
+        data = data[:_max_data_len]
+        if not _data_re.match(data)
             return
-        (local_addr, port) = match.groups()
+        splitted = data.split()
+        port = splitted[0]
+        flags = splitted[1:]
 
-        remote_addr = self.transport.getPeer().host
-        self_peer = self_peer_short = '%s:%s' % (remote_addr, port)
-        if local_addr:
-            self_peer += ('/?nat=%s' % str(local_addr == remote_addr).lower())
+        self_peer = self_peer_short = '%s:%s' % (self.transport.getPeer().host, port)
+        if flags:  # add a query string
+            query = []
+            query.add('nat=%s' % str('nat' in flags).lower())
+            self_peer += '/?' + '&'.join(query)
         random_peer = self_peer
 
         log.msg("registering: %s" % self_peer)

--- a/oonib/testhelpers/peer_locator_helpers.py
+++ b/oonib/testhelpers/peer_locator_helpers.py
@@ -19,11 +19,12 @@ class PeerLocatorProtocol(Protocol):
         match = _data_re.match(data[:_max_data_len])  # protect against garbage
         if not match:
             return
-        (addr, port) = match.groups()
+        (local_addr, port) = match.groups()
 
-        self_peer = self_peer_short = '%s:%s' % (self.transport.getPeer().host, port)
-        if addr:
-            self_peer += ('/?l=%s' % addr)  # add local address
+        remote_addr = self.transport.getPeer().host
+        self_peer = self_peer_short = '%s:%s' % (remote_addr, port)
+        if local_addr:
+            self_peer += ('/?nat=%s' % str(local_addr == remote_addr).lower())
         random_peer = self_peer
 
         log.msg("registering: %s" % self_peer)
@@ -40,7 +41,7 @@ class PeerLocatorProtocol(Protocol):
 
                 log.msg(str(peer_list))
                 log.msg("choosing a random peer from pool of %d peers" % peer_pool_size)
-                # The file may contain ``PUB_ADDR:PORT`` or ``PUB_ADDR:PORT/?l=LOC_ADDR`` entries,
+                # The file may contain ``PUB_ADDR:PORT`` or ``PUB_ADDR:PORT/?QUERY_ARGS`` entries,
                 # do not return any entry with the same ``PUB_ADDR:PORT``.
                 random_peer_short = self_peer_short
                 while(peer_pool_size > 1 and random_peer_short == self_peer_short):

--- a/oonib/testhelpers/peer_locator_helpers.py
+++ b/oonib/testhelpers/peer_locator_helpers.py
@@ -4,6 +4,11 @@ from oonib.config import config
 from oonib import log
 
 import random
+import re
+
+_max_data_len = len('[0123:4567:89ab:cdef:0123:4567:89ab:cdef]:65535')
+# Accept ``PORT`` or ``ADDR:PORT`` with IPv4 ``ADDR`` or IPv6 ``[ADDR]``.
+_data_re = re.compile('^(?:([.0-9]+|\[[:0-9a-fA-F]+\]):)?([0-9]+)$')
 
 class PeerLocatorProtocol(Protocol):
     """
@@ -11,7 +16,16 @@ class PeerLocatorProtocol(Protocol):
     and send another pair in response
     """
     def dataReceived(self, data):
-        self_peer = random_peer = '%s:%s' % (self.transport.getPeer().host, data)
+        match = _data_re.match(data[:_max_data_len])  # protect against garbage
+        if not match:
+            return
+        (addr, port) = match.groups()
+
+        self_peer = self_peer_short = '%s:%s' % (self.transport.getPeer().host, port)
+        if addr:
+            self_peer += ('/?l=%s' % addr)  # add local address
+        random_peer = self_peer
+
         log.msg("registering: %s" % self_peer)
         try:
             with open(config.helpers['peer-locator'].peer_list, 'a+') as peer_list_file:
@@ -26,14 +40,20 @@ class PeerLocatorProtocol(Protocol):
 
                 log.msg(str(peer_list))
                 log.msg("choosing a random peer from pool of %d peers" % peer_pool_size)
-                while(peer_pool_size > 1 and random_peer == self_peer):
+                # The file may contain ``PUB_ADDR:PORT`` or ``PUB_ADDR:PORT/?l=LOC_ADDR`` entries,
+                # do not return any entry with the same ``PUB_ADDR:PORT``.
+                random_peer_short = self_peer_short
+                while(peer_pool_size > 1 and random_peer_short == self_peer_short):
+                    # If the list only contains the sort and a long version of the same peer,
+                    # this will loop forever.  However this should be a very rare case.
                     random_peer = random.choice(peer_list)
+                    random_peer_short = random_peer.split('/')[0]
 
         except IOError as e:
             log.msg("IOError %s" % e)
 
         log.msg("seeding peer %s to peer %s" % (random_peer, self_peer))
-        if (random_peer == self_peer):
+        if (random_peer_short == self_peer_short):
             random_peer = ''
 
         self.transport.write(random_peer)


### PR DESCRIPTION
This change allows the helper to accept both the old ``PORT`` and the
new ``ADDRESS:PORT``, where ``ADDRESS`` is expected to be the local
outgoing interface address of the established connection as the peer
sees it, i.e. not as the helper sees it, since it may have been changed
by NAT.

The new information is saved locally as ``PUB_ADDR:PORT/?l=LOC_ADDR`` if
there's not an identical entry in the file.  A similarly formatted entry
may be provided back to the peer.  When the peer builds the URL (even if
it knows nothing about local addresses), the URL will reflect both the
public and local addresses of the other peer, which should help telling
apart connections not working because of NAT (a normal case) or because
of other reasons.

Old ``PUB_ADDR:PORT`` entries are kept and may also be returned to peers.

This PR builds upon #1.